### PR TITLE
Fix windows paths and improve some UX

### DIFF
--- a/src/ConverterGuiProxy.cpp
+++ b/src/ConverterGuiProxy.cpp
@@ -12,7 +12,6 @@ void ConverterGuiProxy::convert(QConversionType type, QString input,
     input  = QUrl::fromUserInput(input).toLocalFile();
     output = QUrl::fromUserInput(output).toLocalFile();
 
-    qDebug() << input << output;
     auto converter = ConverterFactory::make_converter(
         static_cast<ConverterFactory::ConversionType>(type),
         input.toStdString(), output.toStdString(),

--- a/src/ConverterGuiProxy.cpp
+++ b/src/ConverterGuiProxy.cpp
@@ -8,8 +8,11 @@ void ConverterGuiProxy::convert(QConversionType type, QString input,
                                 QString output, QString field_separator,
                                 QString string_separator)
 {
-    input.remove("file://");
-    output.remove("file://");
+    // Remove file:// on linux and file:/// on windows
+    input  = QUrl::fromUserInput(input).toLocalFile();
+    output = QUrl::fromUserInput(output).toLocalFile();
+
+    qDebug() << input << output;
     auto converter = ConverterFactory::make_converter(
         static_cast<ConverterFactory::ConversionType>(type),
         input.toStdString(), output.toStdString(),

--- a/src/ConverterGuiProxy.hpp
+++ b/src/ConverterGuiProxy.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "ConverterFactory.hpp"
-
+#include <QUrl>
 #include <QObject>
 
 class ConverterGuiProxy : public QObject

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,10 +3,15 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
+#include <QQuickWindow>
 
 int main(int argc, char **argv)
 {
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+
+#ifdef Q_OS_WINDOWS
+    QQuickWindow::setTextRenderType(QQuickWindow::TextRenderType::NativeTextRendering);
+#endif
 
     QGuiApplication app(argc, argv);
     app.setOrganizationName("Federico Guerinoni");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,7 @@ int main(int argc, char **argv)
     QGuiApplication app(argc, argv);
     app.setOrganizationName("Federico Guerinoni");
     app.setOrganizationDomain("Federico Guerinoni");
+    app.setApplicationName("qt-ts-csv");
 
     QQmlApplicationEngine engine;
 

--- a/src/main.qml
+++ b/src/main.qml
@@ -4,11 +4,12 @@ import Qt.labs.platform 1.0
 import QtQuick.Controls 2.4
 import QtQuick.Layouts 1.3
 import QtQuick.Dialogs 1.2
+import QtQuick.Controls.Material 2.0
 
 Window {
     title: qsTr("Ts2Csv Converter ") + version
 
-    minimumHeight: 200
+    minimumHeight: 220
     minimumWidth: 800
 
     height: minimumHeight
@@ -23,7 +24,7 @@ Window {
     GridLayout {
         anchors {
             fill: parent
-            margins: 10
+            margins: 20
         }
 
         columns: 1
@@ -38,11 +39,11 @@ Window {
             Text {
                 id: sourceInput
                 Layout.fillWidth: true
-                text: ""
             }
 
             Button {
                 text: qsTr("Browse")
+                highlighted: true
                 onClicked: {
                     choosingFile = true
                     fileDialog.open()
@@ -59,11 +60,11 @@ Window {
             Text {
                 id: sourceOutput
                 Layout.fillWidth: true
-                text: ""
             }
 
             Button {
                 text: qsTr("Browse")
+                highlighted: true
                 onClicked: {
                     choosingFile = false
                     fileDialog.open()
@@ -87,7 +88,6 @@ Window {
                 visible: isCsvFormat
                 border.width: 0.5
                 border.color: "black"
-                color: "transparent"
                 width: 30
                 height: 30
 
@@ -122,6 +122,8 @@ Window {
         Button {
             Layout.fillWidth: true
             text: qsTr("Convert")
+            highlighted: true
+             Material.background: Material.Orange
             enabled: sourceInput.text.length !== 0
                      && sourceOutput.text.length !== 0
                      && fieldSeparator.text.length !== 0

--- a/src/main.qml
+++ b/src/main.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.0
 import QtQuick.Window 2.11
 import Qt.labs.platform 1.0
+import Qt.labs.settings 1.0
 import QtQuick.Controls 2.4
 import QtQuick.Layouts 1.3
 import QtQuick.Dialogs 1.2
@@ -20,6 +21,12 @@ Window {
     property bool choosingFile: true
     readonly property bool isCsvFormat: comboType.currentIndex === 0
                                         || comboType.currentIndex === 1
+
+    Settings {
+        id: settings
+        property string lastSourceInput
+        property string lastSourceOutput
+    }
 
     GridLayout {
         anchors {
@@ -46,6 +53,7 @@ Window {
                 highlighted: true
                 onClicked: {
                     choosingFile = true
+                    fileDialog.folder = settings.lastSourceInput
                     fileDialog.open()
                 }
             }
@@ -54,7 +62,7 @@ Window {
         RowLayout {
 
             Text {
-                text: qsTr("Destination filename:")
+                text: qsTr("Destination folder:")
             }
 
             Text {
@@ -67,6 +75,7 @@ Window {
                 highlighted: true
                 onClicked: {
                     choosingFile = false
+                    fileDialog.folder = settings.lastSourceOutput
                     fileDialog.open()
                 }
             }
@@ -140,14 +149,16 @@ Window {
         title: choosingFile ? qsTr("Select File") : qsTr("Select Folder")
         nameFilters: []
         selectFolder: !choosingFile
-        folder: StandardPaths.standardLocations(
-                    StandardPaths.DesktopLocation)[0]
+
 
         onAccepted: {
             if (choosingFile) {
                 sourceInput.text = fileDialog.fileUrl
+                var str = fileDialog.fileUrl.toString()
+                settings.lastSourceInput =  str.substring(0, str.lastIndexOf("/"))
             } else {
                 sourceOutput.text = fileDialog.fileUrl
+                settings.lastSourceOutput =  fileDialog.fileUrl
             }
         }
     }

--- a/src/main.qml
+++ b/src/main.qml
@@ -45,6 +45,7 @@ Window {
 
             Text {
                 id: sourceInput
+                color: Material.color(Material.Grey)
                 Layout.fillWidth: true
             }
 
@@ -67,6 +68,7 @@ Window {
 
             Text {
                 id: sourceOutput
+                color: Material.color(Material.Grey)
                 Layout.fillWidth: true
             }
 
@@ -132,7 +134,7 @@ Window {
             Layout.fillWidth: true
             text: qsTr("Convert")
             highlighted: true
-             Material.background: Material.Orange
+            Material.background: Material.Orange
             enabled: sourceInput.text.length !== 0
                      && sourceOutput.text.length !== 0
                      && fieldSeparator.text.length !== 0
@@ -151,7 +153,6 @@ Window {
         title: choosingFile ? qsTr("Select File") : qsTr("Select Folder")
         nameFilters: []
         selectFolder: !choosingFile
-
 
         onAccepted: {
             if (choosingFile) {

--- a/src/main.qml
+++ b/src/main.qml
@@ -2,7 +2,7 @@ import QtQuick 2.0
 import QtQuick.Window 2.11
 import Qt.labs.platform 1.0
 import Qt.labs.settings 1.0
-import QtQuick.Controls 2.4
+import QtQuick.Controls 2.7
 import QtQuick.Layouts 1.3
 import QtQuick.Dialogs 1.2
 import QtQuick.Controls.Material 2.0
@@ -166,13 +166,40 @@ Window {
         }
     }
 
-    MessageDialog {
+    Dialog {
         id: messageDialog
         visible: false
-        icon: converter.convSuccessfull ? StandardIcon.Information : StandardIcon.Critical
         title: converter.convSuccessfull ? "Conversion completed" : "Conversion failed"
-        text: converter.convMsg
-        detailedText: converter.detailedConvMsg
+        contentItem: Rectangle {
+            implicitWidth: 400
+            implicitHeight: 150
+            ColumnLayout {
+                anchors.fill: parent
+                anchors.margins: 40
+
+                Text {
+                    text: converter.convMsg
+                    Layout.alignment: Qt.AlignHCenter
+                    color: Material.color(Material.Grey)
+                    font.pointSize: 16
+                }
+
+                Text {
+                    text: converter.detailedConvMsg
+                     Layout.alignment: Qt.AlignHCenter
+                     color: Material.color(Material.BlueGrey)
+                }
+
+                Button {
+                    text: qsTr("Ok!")
+                    onClicked: messageDialog.close()
+                    highlighted: true
+                    Material.background: Material.Orange
+                    Layout.fillWidth: true
+                }
+            }
+        }
+
         onAccepted: {
             visible = false
         }

--- a/src/qml.qrc
+++ b/src/qml.qrc
@@ -1,5 +1,6 @@
 <RCC>
     <qresource prefix="/">
         <file>main.qml</file>
+        <file>qtquickcontrols2.conf</file>
     </qresource>
 </RCC>

--- a/src/qtquickcontrols2.conf
+++ b/src/qtquickcontrols2.conf
@@ -1,0 +1,11 @@
+[Controls]
+Style=Material
+
+[Material]
+Theme=Light
+Accent=#607D8B
+Primary=White
+Foreground=Grey
+Font\Family=Roboto
+Font\PixelSize=12
+Variant=Dense


### PR DESCRIPTION
Hi,

This PR fixes:
- Windows path that the user selected  // file:// on Linux and file:/// on windows
- Fix font rendering on windows
- Fix some UI spacing issues

Changes:
- Change dialog to use custom text and buttons
- Change path text color to better distinguish between description and selected path

Adds feature:
- Add QML settings to save the last used path for lastSourceInput and lastSourceOutputFix description to select a folder
- Add some visuals to better guide the user when to press buttons
- Add qtquickcontrols2 file for compact buttons and Material Design style

UI:
![image](https://user-images.githubusercontent.com/1071536/76003056-d4ee0580-5f07-11ea-8dad-35507c22d681.png)

Dialog: 
![image](https://user-images.githubusercontent.com/1071536/76003091-dcadaa00-5f07-11ea-8538-4cec1a56e163.png)
