### PR TITLE
Packages update

### DIFF
--- a/scripts/debian.sh
+++ b/scripts/debian.sh
@@ -21,10 +21,14 @@ cp ../qTsConverter/LICENSE usr/share/licenses/qTsConverter/LICENSE
 
 # desktop and icon
 mkdir -p usr/share/pixmaps/
-cp ../qTsConverter/src/qml/assets/logos/profile.png usr/share/pixmaps/qTsConverter.png
-cp ../qTsConverter/src/qml/assets/logos/vector/isolated-layout.svg usr/share/pixmaps/qTsConverter.svg
+cp ../qTsConverter/src/qml/assets/logos/profile.png usr/share/pixmaps/org.guerinoni.qTsConverter.png
+cp ../qTsConverter/src/qml/assets/logos/vector/isolated-layout.svg usr/share/pixmaps/org.guerinoni.qTsConverter.svg
 mkdir -p usr/share/applications
 cp ../qTsConverter/data/qTsConverter.desktop usr/share/applications/qTsConverter.desktop
+
+# dependency
+mkdir -p usr/lib
+cp ../build/3rd-party/qtxlsx/libQtXlsxWriter.so usr/lib/libQtXlsxWriter.so
 
 # debian stff
 mkdir DEBIAN

--- a/scripts/debian.sh
+++ b/scripts/debian.sh
@@ -5,6 +5,9 @@
 echo "version tag: $1"
 RELEASEDIR="qTsConverter_debian_$1"
 
+# cleanup
+rm -r ../../$RELEASEDIR ../../$RELEASEDIR.deb
+
 # creating package dir
 mkdir "../../$RELEASEDIR"
 cd "../../$RELEASEDIR"
@@ -32,14 +35,14 @@ cp ../build/3rd-party/qtxlsx/libQtXlsxWriter.so usr/lib/libQtXlsxWriter.so
 
 # debian stff
 mkdir DEBIAN
-echo "Package: qTsConverter" > DEBIAN/control
-echo "Version: $$1" >> DEBIAN/control
-echo "Section: custom" >> DEBIAN/control
-echo "Priority: optional" >> DEBIAN/control
-echo "Architecture: all" >> DEBIAN/control
-echo "Essential: no" >> DEBIAN/control
-echo "Maintainer: Stivvo" >> DEBIAN/control
-echo "Description: A simple tool to convert qt translation file (ts) to other format (xlsx / csv) and vice versa" >> DEBIAN/control
-
-cd ..
+cd DEBIAN
+echo "Package: qTsConverter" > control
+echo "Version: $1" >> control
+echo "Section: custom" >> control
+echo "Priority: optional" >> control
+echo "Architecture: x86-64" >> control
+echo "Essential: no" >> control
+echo "Maintainer: Stivvo" >> control
+echo "Description: A simple tool to convert qt translation file (ts) to other format (xlsx / csv) and vice versa" >> control
+cd ../..
 dpkg-deb --build "$RELEASEDIR"

--- a/scripts/debian.sh
+++ b/scripts/debian.sh
@@ -22,16 +22,19 @@ cp ../qTsConverter/README.md usr/share/doc/qTsConverter/README.md
 mkdir -p usr/share/licenses/qTsConverter
 cp ../qTsConverter/LICENSE usr/share/licenses/qTsConverter/LICENSE
 
-# desktop and icon
+# copying desktop
+mkdir -p usr/share/applications
+cp ../qTsConverter/data/qTsConverter.desktop usr/share/applications/qTsConverter.desktop
+sed -i 's/local\///g' usr/share/applications/qTsConverter.desktop
+
+# copying icons
 mkdir -p usr/share/pixmaps/
 cp ../qTsConverter/src/qml/assets/logos/profile.png usr/share/pixmaps/org.guerinoni.qTsConverter.png
 cp ../qTsConverter/src/qml/assets/logos/vector/isolated-layout.svg usr/share/pixmaps/org.guerinoni.qTsConverter.svg
-mkdir -p usr/share/applications
-cp ../qTsConverter/data/qTsConverter.desktop usr/share/applications/qTsConverter.desktop
 
-# dependency
+# copying dependency
 mkdir -p usr/lib
-cp ../build/3rd-party/qtxlsx/libQtXlsxWriter.so usr/lib/libQtXlsxWriter.so
+cp ../build/3rd-party/qtxlsx/libQtXlsxWriter*.so usr/lib/
 
 # debian stff
 mkdir DEBIAN
@@ -40,7 +43,7 @@ echo "Package: qTsConverter" > control
 echo "Version: $1" >> control
 echo "Section: custom" >> control
 echo "Priority: optional" >> control
-echo "Architecture: x86-64" >> control
+echo "Architecture: amd64" >> control
 echo "Essential: no" >> control
 echo "Maintainer: Stivvo" >> control
 echo "Description: A simple tool to convert qt translation file (ts) to other format (xlsx / csv) and vice versa" >> control

--- a/scripts/universal.sh
+++ b/scripts/universal.sh
@@ -3,7 +3,21 @@
 [ -z "$1" ] && echo "please provide a version tag" && exit
 
 echo "version tag: $1"
+# uncompressed universal package directory
 RELEASEDIR="qTsConverter_universal_$1"
+# project name
+N="qTsConverter"
+# install command
+C="install -v -Dm"
+# path for repo assets
+ASSET="$N/src/qml/assets/logos"
+# installation prefix
+FIX="/usr/local"
+# icons install path
+ICON="$FIX/share/icons/hicolor/512x512/apps/org.guerinoni.$N"
+
+rm -r ../../$RELEASEDIR
+rm ../../"$RELEASEDIR.zip"
 
 # creating package dir
 mkdir "../../$RELEASEDIR"
@@ -11,28 +25,40 @@ cd "../../$RELEASEDIR"
 
 # copying binaries
 mkdir -p build/src
-cp ../build/src/qTsConverter build/src/qTsConverter
+cp ../build/src/$N build/src/$N
 
 # copying scripts
-mkdir qTsConverter qTsConverter/scripts
-cp ../qTsConverter/scripts/install.sh qTsConverter/scripts/install.sh
-cp ../qTsConverter/scripts/uninstall.sh uninstall.sh
+mkdir -p $N/scripts
+cp ../$N/scripts/uninstall.sh uninstall.sh
 
-# copying documentation, license, desktop, icons
-cp ../qTsConverter/README.md qTsConverter/README.md
-cp ../qTsConverter/LICENSE qTsConverter/LICENSE
-cp ../qTsConverter/data/qTsConverter.desktop qTsConverter/scripts/qTsConverter.desktop
-mkdir -p qTsConverter/src/qml/assets/logos/vector
-cp ../qTsConverter/src/qml/assets/logos/profile.png qTsConverter/src/qml/assets/logos/profile.png
-cp ../qTsConverter/src/qml/assets/logos/vector/isolated-layout.svg qTsConverter/src/qml/assets/logos/vector/isolated-layout.svg
+# copying documentation, license
+cp ../$N/README.md $N/README.md
+cp ../$N/LICENSE $N/LICENSE
+
+# copying desktop
+mkdir -p $N/data
+cp ../$N/data/$N.desktop $N/data/$N.desktop
+
+# copying icons
+mkdir -p $ASSET/vector
+cp ../$ASSET/profile.png $ASSET/profile.png
+cp ../$ASSET/vector/isolated-layout.svg $ASSET/vector/isolated-layout.svg
+
+# copying dependencies
+mkdir -p build/3rd-party/qtxlsx
+cp ../build/3rd-party/qtxlsx/libQtXlsxWriter.so build/3rd-party/qtxlsx/libQtXlsxWriter.so
 
 # creating install.sh that runs wayPreview/scripts/install.sh
 echo "#!/bin/sh" > install.sh
-echo "cd qTsConverter/scripts/" >> install.sh
-echo "./install.sh" >> install.sh
+echo "${C}755 build/src/$N $FIX/bin/$N" >> install.sh
+echo "${C}755 build/3rd-party/qtxlsx/libQtXlsxWriter.so $FIX/lib/libQtXlsxWriter.so" >> install.sh
+echo "${C}644 $N/LICENSE $FIX/share/licenses/$N/LICENSE" >> install.sh
+echo "${C}644 $N/README.md $FIX/share/doc/$N/README.md" >> install.sh
+echo "${C}644 $N/data/$N.desktop $FIX/share/applications/$N.desktop" >> install.sh
+echo "${C}644 $ASSET/vector/isolated-layout.svg $ICON.svg" >> install.sh
+echo "${C}644 $ASSET/profile.png $ICON.png" >> install.sh
+chmod +x install.sh
 
 cd ..
-rm "$RELEASEDIR.zip"
-zip -r "$RELEASEDIR.zip" "$RELEASEDIR"
 echo "universal package created: $RELEASEDIR.zip"
-
+zip -r "$RELEASEDIR.zip" "$RELEASEDIR"

--- a/scripts/universal.sh
+++ b/scripts/universal.sh
@@ -46,12 +46,12 @@ cp ../$ASSET/vector/isolated-layout.svg $ASSET/vector/isolated-layout.svg
 
 # copying dependencies
 mkdir -p build/3rd-party/qtxlsx
-cp ../build/3rd-party/qtxlsx/libQtXlsxWriter.so build/3rd-party/qtxlsx/libQtXlsxWriter.so
+cp ../build/3rd-party/qtxlsx/libQtXlsxWriter*.so build/3rd-party/qtxlsx/
 
 # creating install.sh that runs wayPreview/scripts/install.sh
 echo "#!/bin/sh" > install.sh
 echo "${C}755 build/src/$N $FIX/bin/$N" >> install.sh
-echo "${C}755 build/3rd-party/qtxlsx/libQtXlsxWriter.so $FIX/lib/libQtXlsxWriter.so" >> install.sh
+echo "${C}755 build/3rd-party/qtxlsx/libQtXlsxWriter*.so $FIX/lib/" >> install.sh
 echo "${C}644 $N/LICENSE $FIX/share/licenses/$N/LICENSE" >> install.sh
 echo "${C}644 $N/README.md $FIX/share/doc/$N/README.md" >> install.sh
 echo "${C}644 $N/data/$N.desktop $FIX/share/applications/$N.desktop" >> install.sh


### PR DESCRIPTION
Both the debian ``debian.sh`` and ``universal.sh`` have been updated to the recent changes. On both:
- install dependencies
- install icons with org.guerinoni prefix (for compatibility with flatpak)
- initial cleanup (delete previously generated output to spot new errors)
- flexible shared lib name

on debian:
- architecture
- edit ``.desktop`` to execute in ``/usr/bin`` (all other methods install in ``/usr/local/bin``)

on universal:
- generate a complete ``install.sh`` with ``echo`` since ``scripts/install.sh`` was removed
- shorter paths thanks to variables
- ``chmod +x install.sh`` automatically