### PR TITLE
Make UI compatible with Qt 5.12 version

### DIFF
--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -1,8 +1,8 @@
-import QtQuick 2.15
+import QtQuick 2.12
 
-import QtQuick.Window 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
+import QtQuick.Window 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Layouts 1.12
 import QtQuick.Controls.Material 2.1
 import Qt.labs.settings 1.0
 


### PR DESCRIPTION
Small change to make the code backward compatible with qt 5.12. I don't think it affects anything functionally. The rest of the qml files already seem to be based off 5.12.