### PR TITLE
Fix windows cli build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,6 @@ set(CMAKE_CXX_FLAGS_INIT
     "-Wtautological-compare"
     "-Wuninitialized")
 
-set(CMAKE_CXX_FLAGS_DEBUG "-g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 
 include(cmake/Sanitizers.cmake)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,3 +42,15 @@ endif()
 
 install(TARGETS ${CMAKE_PROJECT_NAME}
         RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin/)
+
+# copy required dlls to executable on windows
+if(WIN32)
+  cmake_minimum_required(VERSION 3.21)
+  add_custom_command(
+    TARGET ${CMAKE_PROJECT_NAME}
+    POST_BUILD
+    COMMAND
+      ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:${CMAKE_PROJECT_NAME}>
+      $<TARGET_FILE_DIR:${CMAKE_PROJECT_NAME}>
+    COMMAND_EXPAND_LISTS)
+endif()

--- a/src/internal/CsvBuilder.cpp
+++ b/src/internal/CsvBuilder.cpp
@@ -4,6 +4,7 @@
 
 #include <QApplication>
 #include <QFile>
+#include <QFileInfo>
 #include <QTextStream>
 #include <QVersionNumber>
 #include <QtDebug>
@@ -38,7 +39,8 @@ auto CsvBuilder::build(const Result &res) const -> bool
         }
     }
 
-    if (!QtCSV::Writer::write(m_ioParameter.outputFile, strData,
+    auto const info = QFileInfo(m_ioParameter.outputFile);
+    if (!QtCSV::Writer::write(info.absoluteFilePath(), strData,
                               m_ioParameter.csvProperty.field_separator,
                               m_ioParameter.csvProperty.string_separator)) {
         qWarning() << "error writing file";

--- a/src/internal/CsvParser.cpp
+++ b/src/internal/CsvParser.cpp
@@ -2,6 +2,7 @@
 
 #include <QApplication>
 #include <QFile>
+#include <QFileInfo>
 #include <QVersionNumber>
 #include <QtDebug>
 #include <include/qtcsv/reader.h>
@@ -12,8 +13,9 @@ CsvParser::CsvParser(InOutParameter parameter) : Parser{ std::move(parameter) }
 
 auto CsvParser::parse() const -> Result
 {
+    auto const info = QFileInfo(m_ioParameter.inputFile);
     auto list = QtCSV::Reader::readToList(
-        m_ioParameter.inputFile, m_ioParameter.csvProperty.string_separator,
+        info.absoluteFilePath(), m_ioParameter.csvProperty.string_separator,
         m_ioParameter.csvProperty.field_separator);
 
     if (list.isEmpty()) {

--- a/src/internal/CsvParser.cpp
+++ b/src/internal/CsvParser.cpp
@@ -14,7 +14,7 @@ CsvParser::CsvParser(InOutParameter parameter) : Parser{ std::move(parameter) }
 auto CsvParser::parse() const -> Result
 {
     auto const info = QFileInfo(m_ioParameter.inputFile);
-    auto list = QtCSV::Reader::readToList(
+    auto list       = QtCSV::Reader::readToList(
         info.absoluteFilePath(), m_ioParameter.csvProperty.string_separator,
         m_ioParameter.csvProperty.field_separator);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,10 +29,10 @@ auto main(int argc, char **argv) -> int
     QCoreApplication::setApplicationName(QStringLiteral("qTsConverter"));
     QCoreApplication::setApplicationVersion(swVersion());
 #else
-#ifdef Q_OS_WIN
+#    ifdef Q_OS_WIN
     QQuickWindow::setTextRenderType(
         QQuickWindow::TextRenderType::NativeTextRendering);
-#endif
+#    endif
 
     QApplication app(argc, argv);
     QApplication::setOrganizationName(QStringLiteral("Federico Guerinoni"));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,11 +21,6 @@ auto main(int argc, char **argv) -> int
 {
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 
-#ifdef Q_OS_WIN
-    QQuickWindow::setTextRenderType(
-        QQuickWindow::TextRenderType::NativeTextRendering);
-#endif
-
 #ifdef ONLY_CLI
     QCoreApplication app(argc, argv);
     QCoreApplication::setOrganizationName(QStringLiteral("Federico Guerinoni"));
@@ -34,6 +29,11 @@ auto main(int argc, char **argv) -> int
     QCoreApplication::setApplicationName(QStringLiteral("qTsConverter"));
     QCoreApplication::setApplicationVersion(swVersion());
 #else
+#ifdef Q_OS_WIN
+    QQuickWindow::setTextRenderType(
+        QQuickWindow::TextRenderType::NativeTextRendering);
+#endif
+
     QApplication app(argc, argv);
     QApplication::setOrganizationName(QStringLiteral("Federico Guerinoni"));
     QApplication::setOrganizationDomain(QStringLiteral("Federico Guerinoni"));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,3 +38,15 @@ add_test("tst_ts2csv" tst_ts2csv)
 add_test("tst_csv2ts" tst_csv2ts)
 add_test("tst_ts2xlsx" tst_ts2xlsx)
 add_test("tst_xlsx2ts" tst_xlsx2ts)
+
+# copy required dlls to executables on windows
+if(WIN32)
+  cmake_minimum_required(VERSION 3.21)
+  add_custom_command(
+    TARGET tst_ts2csv
+    POST_BUILD
+    COMMAND
+      ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:tst_ts2csv>
+      $<TARGET_FILE_DIR:tst_ts2csv>
+    COMMAND_EXPAND_LISTS)
+endif()


### PR DESCRIPTION
Hi guerinoni,

found this tool and added some changes mainly for windows.

1. Fixed building the cli version on windows
2. Copy dlls into the same folder as the executable
3. fixed relative paths on windows
4. debug symbols on windows need a different compiler switch (the cmake default should be enough?)

Looking forward to your feedback for these changes
Laurent