### PR TITLE
Fix exit code when failed to parse source

### DIFF
--- a/src/internal/Converter.cpp
+++ b/src/internal/Converter.cpp
@@ -11,7 +11,7 @@ auto Converter::process() const -> Converter::CoversionResult
 {
     const auto result = m_parser->parse();
     if (!result.error.isEmpty()) {
-        return CoversionResult(false, QStringLiteral("Failed to parse source!"),
+        return CoversionResult(true, QStringLiteral("Failed to parse source!"),
                                result.error);
     }
 


### PR DESCRIPTION
When failed to parse the source `qTsConverter` returns zero as exit code (i. e. no error). This makes it inconvenient to use the converter in scripts. The problem can be reproduced as follows:

1. Create empty `source.xlsx`
2. Run the command: `./qTsConverter source.xlsx converted.ts && echo ok`

Despite the error message, `qTsConverter` looks successfully completed:
```
false "Failed to parse source!" "Invalid XLSX file, check the headers!"
ok
```